### PR TITLE
fixed include path for config.php

### DIFF
--- a/public/swampy_browser/configs.php
+++ b/public/swampy_browser/configs.php
@@ -1,7 +1,10 @@
 <?php
 //print_r($_COOKIE['author_id']);
 //session_start();
-include('/var/www/mywebapps/PlaceWeb.GitHub/place.web.agamba/application/configs/config.php');
+//include('/var/www/mywebapps/PlaceWeb.GitHub/place.web.agamba/application/configs/config.php');
+include('/var/www/place/application/configs/config.php');
+
+
 
 
 /**


### PR DESCRIPTION
I need to set this absolute path, because the way in which the  TinyMCE plugin is defined. we may want to hack this later and use a relative path.
